### PR TITLE
feature/data

### DIFF
--- a/app/src/main/java/com/myapplication/post/data/local/database/PostDao.kt
+++ b/app/src/main/java/com/myapplication/post/data/local/database/PostDao.kt
@@ -1,0 +1,43 @@
+package com.myapplication.post.data.local.database
+
+import androidx.paging.PagingSource
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.myapplication.post.data.local.entity.PostEntity
+import com.myapplication.post.data.local.entity.PostState
+
+@Dao
+interface PostDao {
+
+    @Query("SELECT * FROM posts WHERE title LIKE '%' || :query || '%' ORDER BY id DESC")
+    fun searchPostsByTitle(query: String): PagingSource<Int, PostEntity>
+
+    @Query("SELECT * FROM posts ORDER BY id DESC")
+    fun getAllPosts(): PagingSource<Int, PostEntity>
+
+    @Query("SELECT * FROM posts WHERE isFavorite = 1 ORDER BY id DESC")
+    fun getFavoritePosts(): PagingSource<Int, PostEntity>
+
+    @Query("SELECT * FROM posts WHERE isMyPost = 1 ORDER BY id DESC")
+    fun getLocallyCreatedPosts(): PagingSource<Int, PostEntity>
+
+    @Query("SELECT id, comment, isFavorite FROM posts WHERE isMyPost = 0")
+    suspend fun getRemotePosts(): List<PostState>
+
+    @Upsert
+    suspend fun upsertPosts(vararg post: PostEntity)
+
+    @Query("UPDATE posts SET comment = :comment WHERE id = :id")
+    suspend fun updatePostComment(id: Int, comment: String?)
+
+    @Query("UPDATE posts SET isFavorite = NOT isFavorite WHERE id = :id")
+    suspend fun togglePostFavorite(id: Int)
+
+    @Query("DELETE FROM posts WHERE id = :id AND isMyPost=1")
+    suspend fun deleteMyPostById(id: Int)
+
+    @Query("DELETE FROM posts WHERE isMyPost = 0 AND isFavorite = 0")
+    suspend fun clearRemoteCachedPosts()
+
+}

--- a/app/src/main/java/com/myapplication/post/data/local/database/PostDatabase.kt
+++ b/app/src/main/java/com/myapplication/post/data/local/database/PostDatabase.kt
@@ -1,0 +1,14 @@
+package com.myapplication.post.data.local.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.myapplication.post.data.local.entity.PostEntity
+
+@Database(
+    entities = [PostEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class PostDatabase : RoomDatabase() {
+    abstract fun postDao(): PostDao
+}

--- a/app/src/main/java/com/myapplication/post/data/local/entity/PostEntity.kt
+++ b/app/src/main/java/com/myapplication/post/data/local/entity/PostEntity.kt
@@ -1,0 +1,16 @@
+package com.myapplication.post.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "posts")
+data class PostEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int,
+    val title: String,
+    val body: String,
+    val userId: Int,
+    val isFavorite: Boolean = false,
+    val comment: String? = null,
+    val isMyPost: Boolean = false,
+)

--- a/app/src/main/java/com/myapplication/post/data/local/entity/PostState.kt
+++ b/app/src/main/java/com/myapplication/post/data/local/entity/PostState.kt
@@ -1,0 +1,7 @@
+package com.myapplication.post.data.local.entity
+
+data class PostState(
+    val id: Int,
+    val isFavorite: Boolean = false,
+    val comment: String? = null
+)

--- a/app/src/main/java/com/myapplication/post/data/mapper/PostMapper.kt
+++ b/app/src/main/java/com/myapplication/post/data/mapper/PostMapper.kt
@@ -1,0 +1,52 @@
+package com.myapplication.post.data.mapper
+
+import com.myapplication.post.data.local.entity.PostEntity
+import com.myapplication.post.data.remote.dto.PostDto
+import com.myapplication.post.domain.model.Post
+
+
+fun PostDto.toDomain(): Post = Post(
+    id = id,
+    title = title,
+    body = body,
+    userId = userId,
+    isMyPost = true,
+    isFavorite = false,
+    comment = null
+)
+
+fun Post.toDto(): PostDto = PostDto(
+    id = id,
+    title = title,
+    body = body,
+    userId = userId
+)
+
+fun PostEntity.toDomain(): Post = Post(
+    id = id,
+    title = title,
+    body = body,
+    userId = userId,
+    isFavorite = isFavorite,
+    comment = comment,
+    isMyPost = isMyPost
+)
+
+fun Post.toEntity(): PostEntity = PostEntity(
+    id = id,
+    title = title,
+    body = body,
+    userId = userId,
+    isFavorite = isFavorite,
+    comment = comment,
+    isMyPost = isMyPost
+)
+
+fun PostDto.toEntity(isFavorite: Boolean = false, comment: String? = null): PostEntity = PostEntity(
+    id = id,
+    title = title,
+    body = body,
+    userId = userId,
+    isFavorite = isFavorite,
+    comment = comment,
+)

--- a/app/src/main/java/com/myapplication/post/data/paging/PostRemoteMediator.kt
+++ b/app/src/main/java/com/myapplication/post/data/paging/PostRemoteMediator.kt
@@ -1,0 +1,58 @@
+package com.myapplication.post.data.paging
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import androidx.room.withTransaction
+import com.myapplication.post.data.local.database.PostDatabase
+import com.myapplication.post.data.local.entity.PostEntity
+import com.myapplication.post.data.mapper.toEntity
+import com.myapplication.post.data.remote.api.PostApiService
+
+/**
+ * RemoteMediator implementation that acts as the single source of truth for posts.
+ * It fetches data from the remote API, merges it with any locally stored favorites and comments,
+ * and then updates the local database in a single transaction to ensure consistency.
+ */
+
+@OptIn(ExperimentalPagingApi::class)
+class PostRemoteMediator(
+    private val api: PostApiService,
+    private val db: PostDatabase
+) : RemoteMediator<Int, PostEntity>() {
+
+    override suspend fun load(
+        loadType: LoadType,
+        state: PagingState<Int, PostEntity>
+    ): MediatorResult {
+        return try {
+            if (loadType == LoadType.REFRESH) {
+                val localPosts = db.postDao().getRemotePosts()
+                val remotePosts = api.getPosts()
+
+                val localPostsMap = localPosts.associateBy { it.id }
+                val mergedPosts = remotePosts.map { remotePost ->
+                    localPostsMap[remotePost.id]?.let { localPost ->
+                        remotePost.toEntity(
+                            isFavorite = localPost.isFavorite,
+                            comment = localPost.comment
+                        )
+                    } ?: remotePost.toEntity()
+                }
+
+                db.withTransaction {
+                    db.postDao().run {
+                        clearRemoteCachedPosts()
+                        upsertPosts(*mergedPosts.toTypedArray())
+                    }
+                }
+
+            }
+
+            MediatorResult.Success(endOfPaginationReached = true)
+        } catch (e: Exception) {
+            MediatorResult.Error(e)
+        }
+    }
+}

--- a/app/src/main/java/com/myapplication/post/data/remote/api/PostApiService.kt
+++ b/app/src/main/java/com/myapplication/post/data/remote/api/PostApiService.kt
@@ -1,0 +1,9 @@
+package com.myapplication.post.data.remote.api
+
+import com.myapplication.post.data.remote.dto.PostDto
+import retrofit2.http.GET
+
+interface PostApiService {
+    @GET("posts")
+    suspend fun getPosts(): List<PostDto>
+}

--- a/app/src/main/java/com/myapplication/post/data/remote/dto/PostDto.kt
+++ b/app/src/main/java/com/myapplication/post/data/remote/dto/PostDto.kt
@@ -1,0 +1,8 @@
+package com.myapplication.post.data.remote.dto
+
+data class PostDto(
+    val id: Int,
+    val title: String,
+    val body: String,
+    val userId: Int
+)

--- a/app/src/main/java/com/myapplication/post/data/repository/PostRepositoryImpl.kt
+++ b/app/src/main/java/com/myapplication/post/data/repository/PostRepositoryImpl.kt
@@ -1,0 +1,76 @@
+package com.myapplication.post.data.repository
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.myapplication.post.data.local.database.PostDatabase
+import com.myapplication.post.data.mapper.toDomain
+import com.myapplication.post.data.mapper.toEntity
+import com.myapplication.post.data.paging.PostRemoteMediator
+import com.myapplication.post.data.remote.api.PostApiService
+import com.myapplication.post.domain.model.Post
+import com.myapplication.post.domain.repository.PostRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class PostRepositoryImpl @Inject constructor(
+    private val db: PostDatabase,
+    private val api: PostApiService
+) : PostRepository {
+
+    private fun createPagingConfig() = PagingConfig(
+        pageSize = 20,
+        initialLoadSize = 30,
+        prefetchDistance = 5,
+        enablePlaceholders = false
+    )
+
+    @OptIn(ExperimentalPagingApi::class)
+    override fun getAllPosts(): Flow<PagingData<Post>> {
+        return Pager(
+            config = createPagingConfig(),
+            remoteMediator = PostRemoteMediator(api, db),
+            pagingSourceFactory = { db.postDao().getAllPosts() }
+        ).flow.map { pagingData -> pagingData.map { entity -> entity.toDomain() } }
+    }
+
+    override fun getFavoritePosts(): Flow<PagingData<Post>> {
+        return Pager(
+            config = createPagingConfig(),
+            pagingSourceFactory = { db.postDao().getFavoritePosts() }
+        ).flow.map { pagingData -> pagingData.map { it.toDomain() } }
+    }
+
+    override suspend fun savePost(post: Post) {
+        db.postDao().upsertPosts(post.toEntity())
+    }
+
+    override suspend fun togglePostFavorite(id: Int) {
+        db.postDao().togglePostFavorite(id)
+    }
+
+    override suspend fun deleteMyPost(id: Int) {
+        db.postDao().deleteMyPostById(id)
+    }
+
+    override fun getMyPosts(): Flow<PagingData<Post>> {
+        return Pager(
+            config = createPagingConfig(),
+            pagingSourceFactory = { db.postDao().getLocallyCreatedPosts() }
+        ).flow.map { pagingData -> pagingData.map { it.toDomain() } }
+    }
+
+    override fun searchPostsByTitle(query: String): Flow<PagingData<Post>> {
+        return Pager(
+            config = createPagingConfig(),
+            pagingSourceFactory = { db.postDao().searchPostsByTitle(query) }
+        ).flow.map { pagingData -> pagingData.map { it.toDomain() } }
+    }
+
+    override suspend fun updatePostComment(id: Int, comment: String?) {
+        db.postDao().updatePostComment(id, comment)
+    }
+}


### PR DESCRIPTION
- Add `PostEntity` to the `Data` layer.
- Add `PostDatabase` for local `Data` storage.
- Implement `PostDao` for Room database operations.
- Add `PostState` to represent the state of posts when updating cached data from remote.
- Add `PostMapper` to convert between `Post` entity and `Post` `DTO/model`.
- Add `PostRemoteMediator` to handle synchronization between remote and local data, achieving a single source of truth.
- Implement `PostAPIService` with corresponding `DTOs` for remote communication.
- Add `PostRepositoryImpl` to implement the `PostRepository` interface from the domain layer.







