### PR TITLE
fix/home-error-image-darkmode

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -11,6 +11,7 @@
         android:layout_width="@dimen/_150sdp"
         android:layout_height="@dimen/_150sdp"
         android:src="@drawable/ic_error"
+        app:tint="@color/black"
         android:visibility="gone"
         android:contentDescription="@string/error_loading_posts"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
- Add color to the `SVG` error image.

